### PR TITLE
Changes related to the Google Lighthouse PWA check to optimize the pwa experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Create the NextJs App ( Repo )
 
 ##### First Create a nextJs application with the below command. I will name the repo as PWA.
@@ -41,18 +40,21 @@ module.exports = nextConfig;
 #
 
 ##### Below I am adding an image of a next.config.json file. So if anyone can understand it should add in the root level and its code.
+
 #
 
 ![next.config.json](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*XCExd5E12Dc8CGtyYBP_vg.png)
+
 #
 
 # Now go to the public folder of the Repo
 
-
 #### Then follow the below steps.
 
 #
+
 - create a file called manifest.json inside the public folder. Then add the below code.
+
 #
 
 ```typescript
@@ -72,18 +74,26 @@ module.exports = nextConfig;
   "icons": [
     {
       "src": "/icon.png",
-      "sizes": "500x500",
+      "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/icon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }
 ```
+
 #
 
 #
+
 - Added an image to the public folder with the correct name and the correct dimensions that you provided in the icons array in the manifest.json file.
-#
 
+#
 
 ```typescript
 // If your icons array is look below.
@@ -91,25 +101,34 @@ module.exports = nextConfig;
 "icons": [
     {
       "src": "/icon.png",
-      "sizes": "192x192",
+      "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/icon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 
-// You should add an image with 
+// You should add an image with
 // - name icon.png
 // - dimensions - 500x500 (canva can be used to get images with dimensions)
 // - type image/png
 ```
+
 #
 
 #### Below I am attaching the image of mainfest.json and icon.png file so you can see the correct level.
+
 #
 
 ![manifest.json](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*8CmDSnvx-mthlsdjmgHoiw.png)
+
 #
 
-# Then go to the _document.tsx or _document.jsx file of your Repo.
+# Then go to the \_document.tsx or \_document.jsx file of your Repo.
 
 #### Added the below metadata and the link tags inside the <Head> tag.
 
@@ -117,6 +136,7 @@ module.exports = nextConfig;
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+<meta name="theme-color" content="#000000" />
 
 {/* make sure to provide the name of your icon in below.*/}
 <link rel="apple-touch-icon" href="/icon.png" />
@@ -126,9 +146,11 @@ module.exports = nextConfig;
 ##### Below is the image of that code.
 
 ![_document.tsx](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*dntgXrGDUmz0hN00IpJbvQ.png)
+
 #
 
 # Now all done. Let’s build the app with the npm run build.
+
 ```
 npm run build
 ```
@@ -144,6 +166,7 @@ npm run start
 #### Desktop
 
 ![PWA](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*4xGyEJcuUWMHCqPKVMp6FQ.png)
+
 #
 
 #### Mobile
@@ -160,13 +183,16 @@ npm run start
 
 #
 
-
 # In case you can’t see the PWA
 
 ![error](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*qrtxx46erHxBxl8oJSAZRQ.png)
 
 #
 
+# Google Lighthouse PWA check
+
+#
+
+![Google Lighthouse Test](https://cdn-images-1.medium.com/max/1600/1*nKAb5CnaJemqpX12pmW2sQ.png)
+
 ##### If you can’t see right-click your browser and click the inspect. Then go to the application tab. Then you can see the errors or warning like below in the Manifest file. That means you did something wrong and please follow the steps correctly again.
-
-

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,8 +9,14 @@
   "icons": [
     {
       "src": "/icon.png",
-      "sizes": "500x500",
+      "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/icon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,8 +8,11 @@ export default function Document() {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+      <meta name="theme-color" content="#000000" />
+
       <link rel="apple-touch-icon" href="/icon.png" />
       <link rel="manifest" href="/manifest.json" />
+
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
Changes
- Added <meta name="theme-color"> to _document.tsx file
- Added maskable icon
- Change the dimension from 500x500 to 512x512 because " Is not configured for a custom splash screenFailures: Manifest does not have a PNG icon of at least 512px" shown by the Google Lighthouse PWA section
- Added these changes to README.md